### PR TITLE
modify EditWindow_getLifeTime

### DIFF
--- a/UI/windows/edit_window.c
+++ b/UI/windows/edit_window.c
@@ -56,10 +56,9 @@ void EditWindow_init(EditWindow* this,Canvas* canvas,Layout layout, Font* header
  * 	EditWindow* this - целевой объект
  *	Value* val - редактируемое значение
  *	char* header - текст заголовка
- *	uint32_t currentTime - текущее время в ms
  */
 
-void EditWindow_start(EditWindow* this, Value* val, char* header, uint32_t currentTime){
+void EditWindow_start(EditWindow* this, Value* val, char* header){
 	this->vlPt = val;
 	Value_copy(this->vlPt,&this->vlCopy);
 	this->vlLocal = *(float*)this->vlCopy.vl;
@@ -68,7 +67,7 @@ void EditWindow_start(EditWindow* this, Value* val, char* header, uint32_t curre
 	this->shStr.shiftFlag = true;
 	this->inProgress = true;
 	this->headerText = header;
-	this->startTime = currentTime;
+	this->lifeTime = 0;
 }
 
 
@@ -81,7 +80,9 @@ void EditWindow_start(EditWindow* this, Value* val, char* header, uint32_t curre
 void EditWindow_draw(EditWindow* this, uint32_t currentTime){
 	if (this->inProgress){
 		int delay = (this->shStr.shiftFlag||this->shStr.shift==0)? EW_SHIFT_PAUSE : EW_SHIFT_TIME;
-		if (TimeUtilities_getDelta32(currentTime,this->shStr.prevTime) > delay){
+		uint32_t delta = TimeUtilities_getDelta32(currentTime,this->shStr.prevTime);
+		this->lifeTime+=delta;
+		if (delta > delay){
 			this->shStr.prevTime=currentTime;
 			this->shStr.shift=!this->shStr.shiftFlag?this->shStr.shift+1:0;
 		}
@@ -174,10 +175,9 @@ bool EditWindow_isRuning(EditWindow* this){
 /*
  * Получить время существования окна
  * 	EditWindow* this - целевой объект
- *	uint32_t currentTime - текущее время в ms
  */
 
-uint32_t EditWindow_getLifeTime(EditWindow* this, uint32_t currentTime){
-	return TimeUtilities_getDelta32(currentTime,this->startTime);
+uint32_t EditWindow_getLifeTime(EditWindow* this){
+	return this->lifeTime;
 }
 

--- a/UI/windows/edit_window.c
+++ b/UI/windows/edit_window.c
@@ -56,9 +56,10 @@ void EditWindow_init(EditWindow* this,Canvas* canvas,Layout layout, Font* header
  * 	EditWindow* this - целевой объект
  *	Value* val - редактируемое значение
  *	char* header - текст заголовка
+ *	uint32_t currentTime - текущее время в ms
  */
 
-void EditWindow_start(EditWindow* this, Value* val, char* header){
+void EditWindow_start(EditWindow* this, Value* val, char* header, uint32_t currentTime){
 	this->vlPt = val;
 	Value_copy(this->vlPt,&this->vlCopy);
 	this->vlLocal = *(float*)this->vlCopy.vl;
@@ -67,6 +68,7 @@ void EditWindow_start(EditWindow* this, Value* val, char* header){
 	this->shStr.shiftFlag = true;
 	this->inProgress = true;
 	this->headerText = header;
+	this->startTime = currentTime;
 }
 
 
@@ -166,3 +168,16 @@ void EditWindow_back(EditWindow* this){
 bool EditWindow_isRuning(EditWindow* this){
 	return this->inProgress;
 }
+
+
+
+/*
+ * Получить время существования окна
+ * 	EditWindow* this - целевой объект
+ *	uint32_t currentTime - текущее время в ms
+ */
+
+uint32_t EditWindow_getLifeTime(EditWindow* this, uint32_t currentTime){
+	return TimeUtilities_getDelta32(currentTime,this->startTime);
+}
+

--- a/UI/windows/edit_window.h
+++ b/UI/windows/edit_window.h
@@ -30,7 +30,7 @@ typedef struct {
 	float vlLocal;			//Переменная для хранения копии
 	char* headerText;		//Текст заголовка
 	EWShiftString shStr;	//Парамеры сдвига бегущей строки
-	uint32_t startTime; 	//Время начала сессии
+	uint32_t lifeTime; 		//Время "жизни" окна
 }EditWindow;
 
 void EditWindow_init(EditWindow* this,Canvas* canvas,Layout layout, Font* headerFont, Font* bodyFont);

--- a/UI/windows/edit_window.h
+++ b/UI/windows/edit_window.h
@@ -28,8 +28,9 @@ typedef struct {
 	Value* vlPt;			//Указатель на "оригинальное" значение
 	Value vlCopy;			//Копия значения
 	float vlLocal;			//Переменная для хранения копии
-	char* headerText;		// Текст заголовка
-	EWShiftString shStr;	// Парамеры сдвига бегущей строки
+	char* headerText;		//Текст заголовка
+	EWShiftString shStr;	//Парамеры сдвига бегущей строки
+	uint32_t startTime; 	//Время начала сессии
 }EditWindow;
 
 void EditWindow_init(EditWindow* this,Canvas* canvas,Layout layout, Font* headerFont, Font* bodyFont);
@@ -41,5 +42,6 @@ void EditWindow_dec(EditWindow* this);
 void EditWindow_enter(EditWindow* this);
 void EditWindow_back(EditWindow* this);
 bool EditWindow_isRuning(EditWindow* this);
+uint32_t EditWindow_getLifeTime(EditWindow* this);
 
 #endif


### PR DESCRIPTION
Добавлен модифицированный метод EditWindow_getLifeTime. 
Расчет времени жизни окна происходит при его отрисовке.
Меньше аргументов в методах EditWindow_start() и EditWindow_getLifeTime() , но мене точный результат с большим количеством вычислений.